### PR TITLE
Fix framer-motion imports

### DIFF
--- a/components/Header/Headercomp/Logo.tsx
+++ b/components/Header/Headercomp/Logo.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { motion } from "../../../node_modules/framer-motion/dist/framer-motion";
+import { motion } from "framer-motion";
 export default function Logo(props: { finishedLoading: boolean }) {
   return (
     <>

--- a/components/Header/StartupLogo/Startup.tsx
+++ b/components/Header/StartupLogo/Startup.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { motion } from "../../../node_modules/framer-motion/dist/framer-motion";
+import { motion } from "framer-motion";
 const Startup = (props) => {
   let WidthBy2 = 0;
   let HeightBy2 = 0;

--- a/components/Home/ThisSiteCantBeReached/ThisCantBeReached.tsx
+++ b/components/Home/ThisSiteCantBeReached/ThisCantBeReached.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { motion } from "../../../node_modules/framer-motion/dist/framer-motion";
+import { motion } from "framer-motion";
 export default function ThisCantBeReached() {
   const [ShowText, setShowText] = React.useState(false);
   let CenterWidth = 0;

--- a/components/Home/WhereIHaveWorked/WhereIHaveWorked.tsx
+++ b/components/Home/WhereIHaveWorked/WhereIHaveWorked.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { motion } from "../../../node_modules/framer-motion/dist/framer-motion";
+import { motion } from "framer-motion";
 import ArrowIcon from "../../Icons/ArrowIcon";
 import UMassChanMedicalSchool from "./Descriptions/UMassChanMedicalSchool";
 import Capgemini from "./Descriptions/Capgemini";


### PR DESCRIPTION
## Summary
- reference framer-motion package directly instead of node_modules paths

## Testing
- `yarn lint` *(fails: package missing from lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_683fae3d590c832484fa70f13c15a596